### PR TITLE
More ways to get the base url on both browser and server

### DIFF
--- a/duality/core.js
+++ b/duality/core.js
@@ -739,6 +739,14 @@ exports.runShow = function (fn, doc, req) {
 
     if (flashmessages) {
         res = flashmessages.updateResponse(req, res);
+    } else {
+        // set the baseURL cookie for the browser
+        var baseURL = utils.getBaseURL(req);
+        cookies.setResponseCookie(req, res, {
+            name: 'baseURL',
+            value : baseURL,
+            path : baseURL
+        });
     }
     req.response_received = true;
     return res;
@@ -864,6 +872,14 @@ exports.runUpdate = function (fn, doc, req, cb) {
 
     if (flashmessages) {
         res = flashmessages.updateResponse(req, res);
+    } else {
+            // set the baseURL cookie for the browser
+            var baseURL = utils.getBaseURL(req);
+            cookies.setResponseCookie(req, res, {
+                name: 'baseURL',
+                value : baseURL,
+                path : baseURL
+            });
     }
     var r = [val ? val[0]: null, res];
     if (req.client && r[0]) {
@@ -1014,6 +1030,14 @@ exports.runList = function (fn, head, req) {
         }
         if (flashmessages) {
             res = flashmessages.updateResponse(req, res);
+        } else {
+                // set the baseURL cookie for the browser
+                var baseURL = utils.getBaseURL(req);
+                cookies.setResponseCookie(req, res, {
+                    name: 'baseURL',
+                    value : baseURL,
+                    path : baseURL
+                });
         }
         _start(res);
     };

--- a/duality/utils.js
+++ b/duality/utils.js
@@ -19,6 +19,7 @@
  */
 
 var settings = require('settings/root'), // settings module is auto-generated
+    cookies = require('cookies'),
     _ = require('underscore')._;
 
 
@@ -118,6 +119,10 @@ exports.getBaseURL = function (/*optional*/req) {
         return settings.baseURL;
     }
     if (exports.isBrowser()) {
+
+        var baseURL = cookies.readBrowserCookie('baseURL');
+        if (baseURL) return baseURL;
+
         var re = new RegExp('(.*\\/_rewrite).*$');
         var match = re.exec(exports.getWindowLocation().pathname);
         if (match) {


### PR DESCRIPTION
Useful for serve apps that can be passed a baseURL via a rewrite with a query, like the garden.
