### PR TITLE
Core preparation for NO-baseUrl-COOKIE switch

### DIFF
--- a/duality/core.js
+++ b/duality/core.js
@@ -681,6 +681,29 @@ exports.parseResponse = function (req, res) {
 };
 
 /**
+ * Helper for runShow/runList/runUpdate.
+ *
+ * @name processFlashmessagesAndCookies (req, res)
+ * @param {Object} req
+ * @param {Object} res
+ * @api public
+ */
+
+exports.processFlashmessagesAndCookies = function (req, res) {
+    if (flashmessages) {
+        res = flashmessages.updateResponse(req, res);
+    } else {
+        // set the baseURL cookie for the browser
+        var baseURL = utils.getBaseURL(req);
+        cookies.setResponseCookie(req, res, {
+            name: 'baseURL',
+            value : baseURL,
+            path : baseURL
+        });
+    }
+};
+
+/**
  * Runs a show function with the given document and request object,
  * emitting relevant events. This function runs both server and client-side.
  *
@@ -715,17 +738,7 @@ exports.runShow = function (fn, doc, req) {
     events.emit('beforeResponseStart', info, req, res);
     events.emit('beforeResponseData', info, req, res, res.body || '');
 
-    if (flashmessages) {
-        res = flashmessages.updateResponse(req, res);
-    } else {
-        // set the baseURL cookie for the browser
-        var baseURL = utils.getBaseURL(req);
-        cookies.setResponseCookie(req, res, {
-            name: 'baseURL',
-            value : baseURL,
-            path : baseURL
-        });
-    }
+    exports.processFlashmessagesAndCookies(req, res);
     req.response_received = true;
     return res;
 };
@@ -847,18 +860,7 @@ exports.runUpdate = function (fn, doc, req, cb) {
     }
     events.emit('beforeResponseStart', info, req, res);
     events.emit('beforeResponseData', info, req, res, res.body || '');
-
-    if (flashmessages) {
-        res = flashmessages.updateResponse(req, res);
-    } else {
-            // set the baseURL cookie for the browser
-            var baseURL = utils.getBaseURL(req);
-            cookies.setResponseCookie(req, res, {
-                name: 'baseURL',
-                value : baseURL,
-                path : baseURL
-            });
-    }
+    exports.processFlashmessagesAndCookies(req, res);
     var r = [val ? val[0]: null, res];
     if (req.client && r[0]) {
         var appdb = db.use(exports.getDBURL(req));
@@ -1006,17 +1008,7 @@ exports.runList = function (fn, head, req) {
         if (res.body) {
             events.emit('beforeResponseData', info, req, res, res.body);
         }
-        if (flashmessages) {
-            res = flashmessages.updateResponse(req, res);
-        } else {
-                // set the baseURL cookie for the browser
-                var baseURL = utils.getBaseURL(req);
-                cookies.setResponseCookie(req, res, {
-                    name: 'baseURL',
-                    value : baseURL,
-                    path : baseURL
-                });
-        }
+        exports.processFlashmessagesAndCookies(req, res);
         _start(res);
     };
     var _send = send;


### PR DESCRIPTION
This pull request is only about small refactoring – I've removed code duplications from duality/core.

In case if this project is not dead – please take a look on [my no_baseUrlCookie-switch](https://github.com/SpeCT/duality/compare/SpeCT:master...SpeCT:no_baseUrlCookie-switch) branch. There is only one extra line of code to let developer switch baseUrl cookie off by configuring kanso.json:

``` json
{
  "name": "blah", "version": "1.0", 
...
  "duality": {
    "no_baseUrlCookie": true
  }
...
}
```

The reason why I do want to turn baseUrl cookie off is next issue: [COUCHDB-1447](https://issues.apache.org/jira/browse/COUCHDB-1447). Shortly – duality prevents CouchDB from sending 'X-Couch-Update-NewRev' header from inside _update handler. Not sure if my workaround should be merged into `master`.
